### PR TITLE
Add temperature option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 * `model_name` (STRING) — например, `deepseek/deepseek-r1-0528:free`
 * `system_prompt` (STRING)
 * `user_prompt` (STRING)
+* `temperature` (FLOAT, по умолчанию 0.7)
 
 **Выход**
 
@@ -75,6 +76,7 @@
 * `user_prompt` (STRING)
 * `img` (IMAGE) — любое изображение Pillow или тензор
 * `max_tokens` (INT, по умолчанию 1024)
+* `temperature` (FLOAT, по умолчанию 0.7)
 
 **Выход**
 
@@ -88,6 +90,7 @@
 * `model_name` (STRING) — `qwen2.5vl:7b`
 * `system_prompt` (STRING)
 * `user_prompt` (STRING)
+* `temperature` (FLOAT, по умолчанию 0.7)
 
 **Выход**
 
@@ -103,6 +106,7 @@
 * `user_prompt` (STRING)
 * `img` (IMAGE)
 * `max_tokens` (INT, по умолчанию 1024)
+* `temperature` (FLOAT, по умолчанию 0.7)
 
 **Выход**
 

--- a/comfyui_ollama_node.py
+++ b/comfyui_ollama_node.py
@@ -17,6 +17,9 @@ class OllamaNode:
                 "model_name":    ("STRING", {"multiline": False}),
                 "system_prompt": ("STRING", {"multiline": True}),
                 "user_prompt":   ("STRING", {"multiline": True}),
+            },
+            "optional": {
+                "temperature": ("FLOAT", {"default": 0.7}),
             }
         }
 
@@ -25,7 +28,7 @@ class OllamaNode:
     FUNCTION     = "call_ollama"
     CATEGORY     = "Ollama"
 
-    def call_ollama(self, ip_port, model_name, system_prompt, user_prompt):
+    def call_ollama(self, ip_port, model_name, system_prompt, user_prompt, temperature=0.7):
         url = f"http://{ip_port}/v1/chat/completions"
         headers = {
             "Content-Type":  "application/json",
@@ -35,12 +38,13 @@ class OllamaNode:
             "messages": [
                 {"role": "system", "content": system_prompt},
                 {"role": "user",   "content": user_prompt}
-            ]
+            ],
+            "options": {"temperature": temperature},
         }
         data = json.dumps(payload).encode("utf-8")
 
         for attempt in range(1, 4):
-            logger.info(f"OllamaNode: Attempt {attempt}/3")
+            logger.info(f"OllamaNode: Attempt {attempt}/3 (temperature={temperature})")
             logger.debug(f"OllamaNode: POST {url} (payload {len(data)} bytes)")
 
             req = urllib.request.Request(url, data=data, headers=headers, method="POST")

--- a/comfyui_ollama_vision_node.py
+++ b/comfyui_ollama_vision_node.py
@@ -26,6 +26,7 @@ class OllamaVisionNode:
             },
             "optional": {
                 "max_tokens": ("INT", {"default": 1024}),
+                "temperature": ("FLOAT", {"default": 0.7}),
             }
         }
 
@@ -58,7 +59,7 @@ class OllamaVisionNode:
             raise TypeError(f"Cannot handle shape: {arr.shape}")
         return Image.fromarray(arr, mode)
 
-    def call_ollama(self, ip_port, model_name, system_prompt, user_prompt, img, max_tokens=1024):
+    def call_ollama(self, ip_port, model_name, system_prompt, user_prompt, img, max_tokens=1024, temperature=0.7):
         try:
             pil = self._to_pil(img)
         except Exception as e:
@@ -82,6 +83,7 @@ class OllamaVisionNode:
             "model":      model_name,
             "messages":   messages,
             "max_tokens": max_tokens,
+            "options": {"temperature": temperature},
         }
         body = json.dumps(payload).encode("utf-8")
 
@@ -89,7 +91,7 @@ class OllamaVisionNode:
         headers = {"Content-Type": "application/json"}
 
         for attempt in range(1, 4):
-            logger.info(f"OllamaVisionNode: Attempt {attempt}/3 (max_tokens={max_tokens})")
+            logger.info(f"OllamaVisionNode: Attempt {attempt}/3 (max_tokens={max_tokens}, temperature={temperature})")
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
             try:
                 with urllib.request.urlopen(req) as resp:

--- a/openrouter_node.py
+++ b/openrouter_node.py
@@ -16,6 +16,10 @@ class OpenRouterNode:
                 "system_prompt": ("STRING", {"multiline": True}),
                 "user_prompt":   ("STRING", {"multiline": True}),
             }
+            ,
+            "optional": {
+                "temperature": ("FLOAT", {"default": 0.7}),
+            }
         }
 
     RETURN_TYPES = ("STRING",)
@@ -23,7 +27,7 @@ class OpenRouterNode:
     FUNCTION     = "call_openrouter"
     CATEGORY     = "OpenRouter"
 
-    def call_openrouter(self, api_key, model_name, system_prompt, user_prompt):
+    def call_openrouter(self, api_key, model_name, system_prompt, user_prompt, temperature=0.7):
         url = "https://openrouter.ai/api/v1/chat/completions"
         headers = {
             "Authorization": f"Bearer {api_key}",
@@ -34,7 +38,8 @@ class OpenRouterNode:
             "messages": [
                 {"role": "system", "content": system_prompt},
                 {"role": "user",   "content": user_prompt}
-            ]
+            ],
+            "temperature": temperature,
         }
         data = json.dumps(payload).encode("utf-8")
 

--- a/openrouter_vision_node.py
+++ b/openrouter_vision_node.py
@@ -26,6 +26,7 @@ class OpenRouterVisionNode:
             "optional": {
                 # new parameter!
                 "max_tokens": ("INT", {"default": 1024}),
+                "temperature": ("FLOAT", {"default": 0.7}),
             }
         }
 
@@ -64,7 +65,7 @@ class OpenRouterVisionNode:
 
         return Image.fromarray(arr, mode)
 
-    def call_openrouter(self, api_key, model_name, system_prompt, user_prompt, img, max_tokens=1024):
+    def call_openrouter(self, api_key, model_name, system_prompt, user_prompt, img, max_tokens=1024, temperature=0.7):
         # 1) Convert to PIL
         try:
             pil = self._to_pil(img)
@@ -91,6 +92,7 @@ class OpenRouterVisionNode:
             "model":      model_name,
             "messages":   messages,
             "max_tokens": max_tokens,              # ← new field
+            "temperature": temperature,
         }
         body = json.dumps(payload).encode("utf-8")
 
@@ -102,7 +104,7 @@ class OpenRouterVisionNode:
 
         # 4) Up to 3 attempts
         for attempt in range(1, 4):
-            logger.info(f"[VisionNode] Attempt {attempt}/3 (max_tokens={max_tokens})")
+            logger.info(f"[VisionNode] Attempt {attempt}/3 (max_tokens={max_tokens}, temperature={temperature})")
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
 
             try:


### PR DESCRIPTION
## Summary
- add optional `temperature` parameter to OpenRouter and Ollama nodes
- log temperature during requests
- document temperature option in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6876a5bffc44832ca69a89d6b1f5fe64