### PR TITLE
Add Hold model toggle for Ollama experimental nodes

### DIFF
--- a/comfyui_ollama_node_experimental.py
+++ b/comfyui_ollama_node_experimental.py
@@ -22,6 +22,7 @@ class OllamaNodeExperimental:
                 "max_tokens":  ("INT",   {"default": 1024}),
                 "temperature": ("FLOAT", {"default": 0.7}),
                 "top_p":       ("FLOAT", {"default": 0.9}),
+                "hold_model":  ("BOOLEAN", {"default": True, "label": "Hold model"}),
             }
         }
 
@@ -31,7 +32,7 @@ class OllamaNodeExperimental:
     CATEGORY     = "Ollama"
 
     def call_ollama(self, ip_port, model_name, system_prompt, user_prompt,
-                    max_tokens=1024, temperature=0.7, top_p=0.9):
+                    max_tokens=1024, temperature=0.7, top_p=0.9, hold_model=True):
         url = f"http://{ip_port}/v1/chat/completions"
         headers = {
             "Content-Type":  "application/json",
@@ -48,6 +49,8 @@ class OllamaNodeExperimental:
                 "top_p":       top_p,
             }
         }
+        if not hold_model:
+            payload["options"]["keep_alive"] = 0
         data = json.dumps(payload).encode("utf-8")
 
         for attempt in range(1, 4):

--- a/comfyui_ollama_vision_node_experimental.py
+++ b/comfyui_ollama_vision_node_experimental.py
@@ -28,6 +28,7 @@ class OllamaVisionNodeExperimental:
                 "max_tokens":  ("INT",   {"default": 1024}),
                 "temperature": ("FLOAT", {"default": 0.7}),
                 "top_p":       ("FLOAT", {"default": 0.9}),
+                "hold_model":  ("BOOLEAN", {"default": True, "label": "Hold model"}),
             }
         }
 
@@ -61,7 +62,7 @@ class OllamaVisionNodeExperimental:
         return Image.fromarray(arr, mode)
 
     def call_ollama(self, ip_port, model_name, system_prompt, user_prompt, img,
-                    max_tokens=1024, temperature=0.7, top_p=0.9):
+                    max_tokens=1024, temperature=0.7, top_p=0.9, hold_model=True):
         try:
             pil = self._to_pil(img)
         except Exception as e:
@@ -90,6 +91,8 @@ class OllamaVisionNodeExperimental:
                 "top_p":       top_p,
             }
         }
+        if not hold_model:
+            payload["options"]["keep_alive"] = 0
         body = json.dumps(payload).encode("utf-8")
 
         url = f"http://{ip_port}/v1/chat/completions"


### PR DESCRIPTION
## Summary
- add `hold_model` boolean option to experimental Ollama nodes
- when disabled, send `keep_alive=0` to unload model from GPU memory

## Testing
- `python -m py_compile comfyui_ollama_node_experimental.py comfyui_ollama_vision_node_experimental.py`

------
https://chatgpt.com/codex/tasks/task_e_6877592afff0832c87203c1270569d63